### PR TITLE
Change data_hash signature to return a dgo.Map instead of dgo.Value

### DIFF
--- a/hiera/function.go
+++ b/hiera/function.go
@@ -11,7 +11,7 @@ type (
 
 	// DataHash is a Hiera 'data_hash' function returns a Map that Hiera can use as the source for
 	// lookups.
-	DataHash func(ic ProviderContext) dgo.Value
+	DataHash func(ic ProviderContext) dgo.Map
 
 	// LookupKey is a Hiera 'lookup_key' function returns the value that corresponds to the given key.
 	LookupKey func(ic ProviderContext, key string) dgo.Value

--- a/register/funcreg_test.go
+++ b/register/funcreg_test.go
@@ -32,10 +32,10 @@ func TestDataDig(t *testing.T) {
 
 func TestDataHash(t *testing.T) {
 	register.Clean()
-	register.DataHash(`l1`, func(ic hiera.ProviderContext) dgo.Value {
+	register.DataHash(`l1`, func(ic hiera.ProviderContext) dgo.Map {
 		return nil
 	})
-	register.DataHash(`l2`, func(ic hiera.ProviderContext) dgo.Value {
+	register.DataHash(`l2`, func(ic hiera.ProviderContext) dgo.Map {
 		return nil
 	})
 	x := ``
@@ -65,7 +65,7 @@ func TestCombo(t *testing.T) {
 	register.DataDig(`l1`, func(ic hiera.ProviderContext, key dgo.Array) dgo.Value {
 		return nil
 	})
-	register.DataHash(`l1`, func(ic hiera.ProviderContext) dgo.Value {
+	register.DataHash(`l1`, func(ic hiera.ProviderContext) dgo.Map {
 		return nil
 	})
 	register.LookupKey(`l1`, func(ic hiera.ProviderContext, key string) dgo.Value {


### PR DESCRIPTION
This commit changes the signature of the function type for data_hash
so that it must return a `dgo.Map` instead of the generic `dgo.Value`.

Closes #1