### PR TITLE
Support plugins with unix socket transport.

### DIFF
--- a/plugin/server.go
+++ b/plugin/server.go
@@ -93,7 +93,7 @@ func tempFile(dir, prefix string) (string, error) {
 			return path, nil
 		}
 
-		filename = filename + strconv.Itoa(seed.Int())[:1]
+		filename += strconv.Itoa(seed.Int())[:1]
 	}
 
 	return "", fmt.Errorf("failed to generate temporary file in %s", dir)


### PR DESCRIPTION
This feature introduces support for hiera plugins communicating via unix
sockets. Unix sockets are more secure then tcp sockets listening on
localhost which is important for hiera plugins serving secrets.

This is sdk side of the feature.